### PR TITLE
Add (not-working-yet) example for running pack

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -2,6 +2,8 @@
 
 This directory contains an example package and Dockerfile.
 
+## Generate a new package
+
 The **mypackage** directory was generated using the following command. Note you will need to fix the ownership of these files as they are generated as the root user inside the container.
 
 ```bash
@@ -9,3 +11,11 @@ docker run -ti --rm -v $PWD:/root -w /root linuturk/mono-choco new mypackage --v
 ```
 
 There are some modifications necessary to the generated nuspec file before it will generate a package. Check the file's git history to see those changes.
+
+## `pack` a `nuspec` file
+
+Assuming that you are running the command from the root of the directory containing the package, where its `nuspec` descriptor file is:
+
+```bash
+docker run -ti --volume "${PWD}:/root" -w /root linuturk/mono-choco pack
+```


### PR DESCRIPTION
This illustrates what I'm trying to do. I'm running the command from within the directory that contains my ready-to-pack package.

The docker run output:

```shell
$ docker run -ti --rm --volume "${PWD}:/root" -w /root linuturk/mono-choco --verbose --debug pack

Chocolatey v0.10.9.0
Chocolatey is running on Linux v 4.9.60.0
Attempting to delete file "opt/chocolatey/chocolatey.dll.old".
Attempting to delete file "/opt/chocolatey/choco.exe.old".
Attempting to create directory "/root/opt/chocolatey/helpers".
Attempting to create directory "/root/opt/chocolatey/helpers/functions".
Attempting to create directory "/root/opt/chocolatey/redirects".
Attempting to create directory "/root/opt/chocolatey/tools".
Command line: /opt/chocolatey/choco.exe --verbose --debug pack --allow-unofficial
Received arguments: --verbose --debug pack --allow-unofficial
RemovePendingPackagesTask is now ready and waiting for PreRunMessage.
Sending message 'PreRunMessage' out if there are subscribers...
[Pending] Removing all pending packages that should not be considered installed...
Directory 'opt/chocolatey/lib' does not exist.
Sending message 'PostRunMessage' out if there are subscribers...
Exiting with 1
```