### PR TITLE
Use archive for now-retired wheezy, fixes #15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM mono:3.12.1 as builder
 ARG CHOCOVERSION=stable
 
+RUN echo "deb http://archive.debian.org/debian/ wheezy main contrib non-free" >/etc/apt/sources.list
 RUN apt-get update && apt-get install -y wget tar gzip
 
 WORKDIR /usr/local/src
@@ -13,9 +14,8 @@ RUN chmod +x build.sh zip.sh
 RUN ./build.sh -v
 
 
-FROM debian
-
-RUN apt update && apt install -y mono-devel && apt-get clean all
+FROM debian:stretch
+RUN apt-get update && apt-get install -y mono-devel && apt-get clean all
 COPY --from=builder /usr/local/src/choco/build_output/chocolatey /opt/chocolatey
 COPY bin/choco /usr/bin/choco
 


### PR DESCRIPTION
OP #15: Since Debian wheezy is now completely retired, this image doesn't build any more. 

It's painful to continue to use super-old base images, but here's the fix to at least get it to build. 

I worked on this in the vain hope of getting https://github.com/Linuturk/mono-choco/issues/8 resolved (It's an active issue, needs to be reopened). But it did not solve #8 for me.