### PR TITLE
pull the latest version of mono instead of pinning to an old version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:3.12.1 as builder
+FROM mono as builder
 ARG CHOCOVERSION=stable
 
 RUN echo "deb http://archive.debian.org/debian/ wheezy main contrib non-free" >/etc/apt/sources.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,32 @@
-FROM mono as builder
+FROM mono:6.8
 ARG CHOCOVERSION=stable
 
-RUN echo "deb http://archive.debian.org/debian/ wheezy main contrib non-free" >/etc/apt/sources.list
+# Add contrib and non-free
+#RUN echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" >/etc/apt/sources.list
 RUN apt-get update && apt-get install -y wget tar gzip
 
-WORKDIR /usr/local/src
-RUN wget "https://github.com/chocolatey/choco/archive/${CHOCOVERSION}.tar.gz"
-RUN tar -xzf "${CHOCOVERSION}.tar.gz"
-RUN mv "choco-${CHOCOVERSION}" choco
+# Import some additional certs
+WORKDIR /tmp
+RUN wget https://ssl-ccp.godaddy.com/repository/gdig2.crt.pem
+RUN cat gdig2.crt.pem >> /etc/ssl/certs/ca-certificates.crt
+RUN cert-sync /etc/ssl/certs/ca-certificates.crt
 
+# Download, extract, and move chocolatey installer
+WORKDIR /usr/local/src
+RUN wget "https://github.com/chocolatey/choco/archive/${CHOCOVERSION}.tar.gz" && \
+    tar -xzf "${CHOCOVERSION}.tar.gz" && \
+    rm "${CHOCOVERSION}.tar.gz" && \
+    mv "choco-${CHOCOVERSION}" choco
+
+# Build chocolatey
 WORKDIR /usr/local/src/choco
 RUN chmod +x build.sh zip.sh
 RUN ./build.sh -v
 
+# Symlink the build output to our install directory
+RUN ln -s /usr/local/src/choco/build_output/chocolatey /opt/chocolatey
 
-FROM debian:stretch
-RUN apt-get update && apt-get install -y mono-devel curl && apt-get clean all
-RUN curl https://ssl-ccp.godaddy.com/repository/gdig2.crt.pem -o gdig2.crt.pem
-RUN cat gdig2.crt.pem >> /etc/ssl/certs/ca-certificates.crt
-RUN cert-sync /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /usr/local/src/choco/build_output/chocolatey /opt/chocolatey
+# Copy in the choco helper script
 COPY bin/choco /usr/bin/choco
 
 ENTRYPOINT ["/usr/bin/choco"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM mono:6.8
 ARG CHOCOVERSION=stable
 
-# Add contrib and non-free
-#RUN echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" >/etc/apt/sources.list
+# Make sure we have these tools
 RUN apt-get update && apt-get install -y wget tar gzip
 
 # Import some additional certs


### PR DESCRIPTION
Fixes #18 