### PR TITLE
Update Choco to build with latest mono.

### DIFF
--- a/bin/choco
+++ b/bin/choco
@@ -1,14 +1,5 @@
 #!/bin/bash
 set -e
 
-# choco dumps a ton of stuff in the PWD/opt
-# This hack will clean it up automatically.
-function cleanup {
-	if [ $PWD != "/" ] && [ -d opt ]; then
-		rm -rf opt
-	fi
-}
-trap cleanup EXIT
-
 # Wrap the mono choco.exe command
-mono /opt/chocolatey/choco.exe "$@" --allow-unofficial
+mono /opt/chocolatey/console/choco.exe "$@" --allow-unofficial


### PR DESCRIPTION
This does a couple things-
1. Update to build with mono 6.8 and removes stuff related to that.
2. Remove certificate workaround as it has been fixed upstream.
3. Add the `ChocolateyInstall` environment variable. This fixes choco dumping stuff in the current working directory, and also the error about not finding the lib directory.
4. Use the `code_drop` rather than the `build_output` directory. `code_drop` is what the `zip.sh` script uses I think.